### PR TITLE
Added cloudflare ip source module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM caddy:2.9.1-builder AS builder
 
 RUN xcaddy build \
-    --with github.com/caddy-dns/cloudflare
+    --with github.com/caddy-dns/cloudflare \
+    --with github.com/WeidiDeng/caddy-cloudflare-ip
 
 FROM caddy:2.9.1
 


### PR DESCRIPTION
Added caddy-cloudflare-ip trusted_proxies ip source module. As presumably someone who is using cloudflare for their DNS may also want the option to automatically get an up to date list of IPs that cloudflare may proxy their traffic from.